### PR TITLE
remove special casing for singleton arrays

### DIFF
--- a/chai-match-json.js
+++ b/chai-match-json.js
@@ -98,10 +98,6 @@
 
       return Object.keys(paths).every(function(prop) {
         var expectation = jsonPath.eval(obj, prop)[0];
-        if (expectation instanceof Array && expectation.length === 1) {
-          expectation = expectation[0];
-        }
-
         return utils.eql(expectation, paths[prop]);
       });
     }
@@ -282,7 +278,18 @@ function jsonPath(obj, expr, arg) {
 }
 })(typeof exports === 'undefined' ? this['jsonPath'] = {} : exports, typeof require == "undefined" ? null : require);
 
-},{"vm":3}],3:[function(require,module,exports){
+},{"vm":4}],3:[function(require,module,exports){
+
+var indexOf = [].indexOf;
+
+module.exports = function(arr, obj){
+  if (indexOf) return arr.indexOf(obj);
+  for (var i = 0; i < arr.length; ++i) {
+    if (arr[i] === obj) return i;
+  }
+  return -1;
+};
+},{}],4:[function(require,module,exports){
 var indexOf = require('indexof');
 
 var Object_keys = function (obj) {
@@ -422,15 +429,4 @@ exports.createContext = Script.createContext = function (context) {
     return copy;
 };
 
-},{"indexof":4}],4:[function(require,module,exports){
-
-var indexOf = [].indexOf;
-
-module.exports = function(arr, obj){
-  if (indexOf) return arr.indexOf(obj);
-  for (var i = 0; i < arr.length; ++i) {
-    if (arr[i] === obj) return i;
-  }
-  return -1;
-};
-},{}]},{},[1]);
+},{"indexof":3}]},{},[1]);

--- a/lib/match-json.js
+++ b/lib/match-json.js
@@ -97,10 +97,6 @@
 
       return Object.keys(paths).every(function(prop) {
         var expectation = jsonPath.eval(obj, prop)[0];
-        if (expectation instanceof Array && expectation.length === 1) {
-          expectation = expectation[0];
-        }
-
         return utils.eql(expectation, paths[prop]);
       });
     }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "JSONPath": "^0.10.0"
   },
   "devDependencies": {
+    "mocha": "^2.4.5",
     "chai": "^1.10.0",
     "karma": "^0.12.31",
     "karma-browserify": "^2.0.0",

--- a/tests/match-json.js
+++ b/tests/match-json.js
@@ -13,6 +13,21 @@ var FIXTURE = [
     name: 'Object 2',
     value: 'Value 2',
     space: 'One'
+  },
+  {
+    deepest: {
+      deeper: {
+        deep: 3
+      }
+    },
+    array1: [
+      41
+    ],
+    array3: [
+      42,
+      43,
+      44
+    ]
   }
 ];
 
@@ -28,6 +43,40 @@ describe('match-json', function() {
     expect(FIXTURE).to.matchJSON({
       '$.name'  : 'Object 2',
       '$.value' : 'Value 2'
+    });
+  });
+
+  it('should match against deep objects', function() {
+    expect(FIXTURE).to.matchJSON({
+      '$.deepest': { deeper: { deep: 3 } }
+    });
+
+    expect(FIXTURE).to.matchJSON({
+      '$.deepest.deeper': { deep: 3 }
+    });
+
+    expect(FIXTURE).to.matchJSON({
+      '$.deepest.deeper.deep': 3
+    });
+  });
+
+  it("should match against arrays", function() {
+    expect(FIXTURE).to.matchJSON({
+      '$.array1': [ 41 ],
+    });
+
+    expect(FIXTURE).to.matchJSON({
+      '$.array1.0': 41,
+    });
+
+    expect(FIXTURE).to.matchJSON({
+      '$.array3': [ 42, 43, 44 ],
+    });
+
+    expect(FIXTURE).to.matchJSON({
+      '$.array3.0': 42,
+      '$.array3.1': 43,
+      '$.array3.2': 44
     });
   });
 


### PR DESCRIPTION
Also, add some tests for arrays and deep objects. Also, I added mocha as a dev dependency and rebuilt with an apparently newer version of browserify ~~(I noticed that the build included a couple of shims that were not present before rebuilding.)~~ It produced different output because apparently browserify has non-deterministic behavior (I wish I could say I was surprised)
